### PR TITLE
Checking button accessibility labels

### DIFF
--- a/src/rules/button-label-required/index.test.tsx
+++ b/src/rules/button-label-required/index.test.tsx
@@ -42,6 +42,13 @@ it("doesn't throw if the button has text content", () => {
   expect(() => run(<Button />)).not.toThrow();
 });
 
+it("doesn't throw if the button has text content", () => {
+  const Button = () => (
+    <TouchableOpacity accessibilityLabel="Test"/>
+  );
+  expect(() => run(<Button />)).not.toThrow();
+});
+
 it("doesn't throw if the button has text + non-text content", () => {
   const Button = () => (
     <TouchableOpacity>

--- a/src/rules/button-label-required/index.ts
+++ b/src/rules/button-label-required/index.ts
@@ -7,10 +7,12 @@ const rule: Rule = {
   id: 'button-label-required',
   matcher: (node) => isButton(node.type),
   assertion: (node) => {
-    let textNode = getTextNode(node);
-    if (!textNode) return false;
-    const textContent = textNode.props.children;
-    if (!textContent) return false;
+    const textNode = getTextNode(node);
+    const textContent = textNode?.props?.children;
+    const accessibilityLabel = node.props.accessibilityLabel;
+    if (!accessibilityLabel && !textContent){
+      return false; 
+    }
     return true;
   },
   help: {


### PR DESCRIPTION
The rule solution said "Place a text component within the button or define an 'accessibilityLabel' prop" so the rule should pass when accessibilityLable is provided