### PR TITLE
ci: update build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepare": "husky install",
+    "prepare": "husky install && bob build",
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",


### PR DESCRIPTION
When updating husky, `husky install` replaced `bob build` which was used to build the `lib` directory.
This commit just add `bob build` to `prepare` script