### PR TITLE
Support ReactTestInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">
 React Native Accessibility Engine
-</h1> 
+</h1>
 
 <h3 align="center">
 Make accessibility-related assertions in React Native
@@ -13,9 +13,9 @@ Make accessibility-related assertions in React Native
 <div align="center">
   <img alt="npm" src="https://img.shields.io/npm/v/react-native-accessibility-engine">
   <img src="https://img.shields.io/badge/license-MIT-blue.svg" />
-  <img src="https://img.shields.io/badge/contributors-welcome-blue" />  
-  <img src="https://img.shields.io/badge/maintenance-active-green" /> 
-  <img src="https://img.shields.io/badge/support-ios|android-purple" />  
+  <img src="https://img.shields.io/badge/contributors-welcome-blue" />
+  <img src="https://img.shields.io/badge/maintenance-active-green" />
+  <img src="https://img.shields.io/badge/support-ios|android-purple" />
   <a href="https://codecov.io/gh/aryella-lacerda/react-native-accessibility-engine">
     <img src="https://codecov.io/gh/aryella-lacerda/react-native-accessibility-engine/branch/main/graph/badge.svg?token=GQNZ4HXN7Q"/>
   </a>
@@ -60,6 +60,8 @@ yarn add react-native-accessibility-engine --dev
 
 ## Usage
 
+### With React elements
+
 ```tsx
 import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
@@ -73,20 +75,47 @@ const Button = () => (
 );
 
 it('should not have accessibility errors', () => {
-  expect(() => AccessibilityEngine.check(<Button />)).not.toThrow();
+  const element = <Button />;
+  expect(() => AccessibilityEngine.check(element)).not.toThrow();
+});
+
+```
+
+### With React test instances
+
+You can also pass test instances from `react-test-renderer` and
+`@testing-library/react-native`:
+
+```tsx
+import React from 'react';
+import { Image, TouchableOpacity } from 'react-native';
+import TestRenderer, { ReactTestInstance } from 'react-test-renderer';
+import Icons from './assets';
+import AccessibilityEngine from 'react-native-accessibility-engine';
+
+const Button = () => (
+  <TouchableOpacity accessible={false}>
+    <Image source={Icons.filledHeart['32px']} />
+  </TouchableOpacity>
+);
+
+it('should not have accessibility errors', () => {
+  const testInstance = ReactTestInstance.create(<Button />).root;
+  // ...
+  expect(() => AccessibilityEngine.check(testInstance)).not.toThrow();
 });
 
 ```
 
 ## Limitations
 
-Though the goal of this project is eventually to cover a wide variety of components and situations, that's still a work in progress. You can check out [the current list of rules and their descriptions here](./docs/rules-catalog.md). 
+Though the goal of this project is eventually to cover a wide variety of components and situations, that's still a work in progress. You can check out [the current list of rules and their descriptions here](./docs/rules-catalog.md).
 
 ## Contributing
 
 <div>
-<img src="https://img.shields.io/badge/contributors-welcome-blue" />  
-<img src="https://img.shields.io/badge/maintenance-active-green" />  
+<img src="https://img.shields.io/badge/contributors-welcome-blue" />
+<img src="https://img.shields.io/badge/maintenance-active-green" />
 </div>
 
 This project is totally open to questions, sugestions, corrections, and community pull requests. We've tried to make contributing as painless a process as possible. Take a look at our guides:

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,1 +1,2 @@
+import '@testing-library/jest-native';
 import '@testing-library/jest-native/extend-expect';

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@react-native-community/slider": "4.1.7",
     "@release-it/conventional-changelog": "3.3.0",
     "@testing-library/jest-native": "4.0.2",
+    "@testing-library/react-native": "^8.0.0",
     "@types/jest": "26.0.24",
     "@types/lodash.groupby": "4.6.6",
     "@types/react": "17.0.27",

--- a/src/engine/index.test.tsx
+++ b/src/engine/index.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Image, TouchableOpacity } from 'react-native';
+import { render } from '@testing-library/react-native';
 import Icons from 'tests/assets';
 import AccessibilityEngine from 'react-native-accessibility-engine';
 
@@ -11,4 +12,10 @@ const Button = () => (
 
 it('should not contain accessibility errors', () => {
   expect(() => AccessibilityEngine.check(<Button />)).toThrow();
+});
+
+it('should support test instances', () => {
+  const { UNSAFE_getByType } = render(<Button />);
+  const button = UNSAFE_getByType(TouchableOpacity);
+  expect(() => AccessibilityEngine.check(button)).toThrow();
 });

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -5,5 +5,6 @@ export { default as isHidden } from './isHidden';
 
 export { default as canBeDisabled } from './canBeDisabled';
 export { default as isFunctionalComponent } from './isFunctionalComponent';
+export { default as isReactTestInstance } from './isReactTestInstance';
 export { default as getComponentName } from './getComponentName';
 export { default as getPathToComponent } from './getPathToComponent';

--- a/src/helpers/isReactTestInstance/index.ts
+++ b/src/helpers/isReactTestInstance/index.ts
@@ -1,0 +1,2 @@
+import isReactTestInstance from './isReactTestInstance';
+export default isReactTestInstance;

--- a/src/helpers/isReactTestInstance/isReactTestInstance.test.ts
+++ b/src/helpers/isReactTestInstance/isReactTestInstance.test.ts
@@ -1,0 +1,20 @@
+import React from 'react';
+import { View } from 'react-native';
+import isReactTestInstance from './isReactTestInstance';
+import TestRenderer from 'react-test-renderer';
+import { render } from '@testing-library/react-native';
+
+it('should return false when passed a React element', () => {
+  expect(isReactTestInstance(React.createElement(View))).toBe(false);
+});
+
+it('should return true when passed a ReactTestInstance from react-test-renderer', () => {
+  expect(
+    isReactTestInstance(TestRenderer.create(React.createElement(View)).root)
+  ).toBe(true);
+});
+
+it('should return true when passed a ReactTestInstance from @testing-library/react-native', () => {
+  const { getByTestId } = render(React.createElement(View, { testID: 'view' }));
+  expect(isReactTestInstance(getByTestId('view'))).toBe(true);
+});

--- a/src/helpers/isReactTestInstance/isReactTestInstance.ts
+++ b/src/helpers/isReactTestInstance/isReactTestInstance.ts
@@ -1,4 +1,10 @@
+import React from 'react';
 import type { ReactTestInstance } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
+
+const testInstancePrototype = Object.getPrototypeOf(
+  create(React.createElement('div')).root
+);
 
 export default function isReactTestInstance(
   candiate: unknown
@@ -6,6 +12,6 @@ export default function isReactTestInstance(
   return (
     !!candiate &&
     typeof candiate === 'object' &&
-    'instance' in (candiate as any)
+    Object.getPrototypeOf(candiate) === testInstancePrototype
   );
 }

--- a/src/helpers/isReactTestInstance/isReactTestInstance.ts
+++ b/src/helpers/isReactTestInstance/isReactTestInstance.ts
@@ -1,0 +1,11 @@
+import type { ReactTestInstance } from 'react-test-renderer';
+
+export default function isReactTestInstance(
+  candiate: unknown
+): candiate is ReactTestInstance {
+  return (
+    !!candiate &&
+    typeof candiate === 'object' &&
+    'instance' in (candiate as any)
+  );
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1476,6 +1476,17 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^27.2.5":
+  version "27.2.5"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.2.5.tgz#420765c052605e75686982d24b061b4cbba22132"
+  integrity sha512-nmuM4VuDtCZcY+eTpw+0nvstwReMsjPoj7ZR80/BbixulhLaiX+fbv8oeLW8WZlJMcsGQsTmMKT/iTZu1Uy/lQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^16.0.0"
+    chalk "^4.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -1889,6 +1900,13 @@
     pretty-format "^24.0.0"
     ramda "^0.26.1"
     redent "^2.0.0"
+
+"@testing-library/react-native@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-native/-/react-native-8.0.0.tgz#f1b8f6bcc9f0ef6026b0ec7d072faf4af0e622fa"
+  integrity sha512-XwQIv4Amj8AYsPjASo+1XLFWY7qMm+FyV4+QU5j97CpRd+YasCBNnvfyDAZoudm/5Y0Yx55DYjAX36RugxasPQ==
+  dependencies:
+    pretty-format "^27.0.0"
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -2332,6 +2350,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@^2.0.0:
   version "2.0.0"
@@ -7435,6 +7458,16 @@ pretty-format@^26.0.0, pretty-format@^26.5.2, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.0:
+  version "27.3.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.3.1.tgz#7e9486365ccdd4a502061fa761d3ab9ca1b78df5"
+  integrity sha512-DR/c+pvFc52nLimLROYjnXPtolawm+uWDxr4FjuLDLUn+ktWnSN851KoHwHzzqq6rfCOjkzN8FLgDrSub6UDuA==
+  dependencies:
+    "@jest/types" "^27.2.5"
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 process-nextick-args@~2.0.0:


### PR DESCRIPTION
This patch provides support for ReactTestInstance as argument for `AccessibilityEngine.check`, fixing the issue described in #97. Usage example:

```jsx
it('should support test instances', () => {
  const { UNSAFE_getByType } = render(<Button />);
  const testInstance = UNSAFE_getByType(TouchableOpacity);
  expect(() => AccessibilityEngine.check(testInstance)).toThrow();
});
```
This is a non-breaking change, and makes the API more flexible to fulfill a variety of requirements, since the consumer can choose **when** the assertions should be performed instead of delegating the creation of a test render tree to the accessibility engine. As discussed in #97, an alternative could be to provide different methods, such as `checkElement` and `checkTestInstance` to enhance the transparency of the API.

Another advantage of this approach is that it does not require `@testing-lirbrary/react-native` to be declared as a peer dependency.