### PR TITLE
fix(pressable-role-required): allows radio buttons

### DIFF
--- a/docs/Guidelines.md
+++ b/docs/Guidelines.md
@@ -31,7 +31,7 @@ If it's sometimes dificult even for people with good vision to figure out that c
 ### Can be implemented by:
 - setting the button's `accessibilityRole` prop to `button`.
 - setting the button's `accessibilityRole` prop to `imagebutton` in the event that your button is also an image.
-
+- setting the button's `accessibilityRole` prop to `radio` in the event that your button is part of a `radiogroup` and behaves like a `radio` button: "A checkable input in a group of elements with the same role, only one of which can be checked at a time.".
 ### Example:
 
 ```tsx

--- a/src/rules/pressable-role-required/index.test.tsx
+++ b/src/rules/pressable-role-required/index.test.tsx
@@ -59,3 +59,13 @@ it("doesn't throw if 'accessibilityRole' prop has the value 'imagebutton'", () =
 
   expect(() => run(<Button />)).not.toThrowError(rule.help.problem);
 });
+
+it("doesn't throw if 'accessibilityRole' prop has the value 'radio'", () => {
+  const Button = () => (
+    <TouchableOpacity accessibilityRole={'radio'}>
+      <Image source={TestAssets.heart['32px']} />
+    </TouchableOpacity>
+  );
+
+  expect(() => run(<Button />)).not.toThrowError(rule.help.problem);
+});

--- a/src/rules/pressable-role-required/index.ts
+++ b/src/rules/pressable-role-required/index.ts
@@ -1,16 +1,17 @@
 import type { Rule } from '../../types';
 import { isButton } from '../../helpers';
 
+const allowedRoles = ['button', 'link', 'imagebutton', 'radio'];
+const allowedRolesMessage = allowedRoles.join(' or ');
+
 const rule: Rule = {
   id: 'pressable-role-required',
   matcher: (node) => isButton(node.type),
-  assertion: (node) =>
-    ['button', 'link', 'imagebutton'].includes(node.props.accessibilityRole),
+  assertion: (node) => allowedRoles.includes(node.props.accessibilityRole),
   help: {
     problem:
-      'If a component is touchable/pressable, we should inform the user that it behaves like a button/link',
-    solution:
-      "Set the 'accessibilityRole' prop with a value of 'button' or 'link' or 'imagebutton'",
+      'If a component is touchable/pressable, we should inform the user that it behaves like a button/link/radio',
+    solution: `Set the 'accessibilityRole' prop with a value of ${allowedRolesMessage}`,
     link: '',
   },
 };


### PR DESCRIPTION
Assuming the following component was present in a code base:
```jsx
<View accessibilityRole="radiogroup">
  <Pressable accessibilityRole="radio" accessibilityState={ checked: checked === "this one" } />
  <Pressable accessibilityRole="radio" accessibilityState={ checked: checked === "that one" } />
</View>
```
Then the `pressable-role-required` rule was being triggered due to the role not being `button`, `link` or `imagebutton`.
This PR allows a pressable to have a role of `radio`.

Let me know if this is okay @aryella-lacerda.
Thanks for this library!