### PR TITLE
chore: prevent patch-package from running in production

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,12 +25,11 @@
     "test": "jest",
     "typescript": "tsc --noEmit",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
-    "prepare": "husky install && bob build",
+    "prepare": "husky install && bob build && patch-package",
     "release": "release-it",
     "example": "yarn --cwd example",
     "pods": "cd example && pod-install --quiet",
-    "bootstrap": "yarn example && yarn && yarn pods",
-    "postinstall": "patch-package"
+    "bootstrap": "yarn example && yarn && yarn pods"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
## Context

Last week, it was necessary to patch React Native after the 0.67 upgrade, which included a bug in the Jest setup script. 

## Problem

As this bug occurred only in development, `patch-package` was installed as a devDependency. However, the `post-install` script, which was previously responsible for running `patch-package`, also runs in production, which caused an error upon installation. 

## Correction

The script now responsible for running `patch-package` is `prepare`, which only runs in development.