### PR TITLE
fix: export types from extend-expect file to better support TS

### DIFF
--- a/src/extend-expect.ts
+++ b/src/extend-expect.ts
@@ -1,3 +1,4 @@
 import * as extensions from './matchers';
+export * from './types';
 
 expect.extend(extensions);


### PR DESCRIPTION
## Context

It would be nice to support Typescript right out of the box, but right now, you have to import something from the entry file or the entry file itself in order for the client project to parse the files. This is in addition to the `extend-expect` file that the client project must already add to Jest's `setupFilesAfterEnv` array.

## Correction

The entry file is currently the only one that exports the matcher types. The idea is to export them also from the extend-expect file, such that in the future the client project will only need to add that file to the `setupFilesAfterEnv` for the types to be parsed.