### PR TITLE
Support checkbox role for Pressables

### DIFF
--- a/src/rules/pressable-role-required/index.test.tsx
+++ b/src/rules/pressable-role-required/index.test.tsx
@@ -69,3 +69,13 @@ it("doesn't throw if 'accessibilityRole' prop has the value 'radio'", () => {
 
   expect(() => run(<Button />)).not.toThrowError(rule.help.problem);
 });
+
+it("doesn't throw if 'accessibilityRole' prop has the value 'checkbox'", () => {
+  const Button = () => (
+    <TouchableOpacity accessibilityRole={'checkbox'}>
+      <Image source={TestAssets.heart['32px']} />
+    </TouchableOpacity>
+  );
+
+  expect(() => run(<Button />)).not.toThrowError(rule.help.problem);
+});

--- a/src/rules/pressable-role-required/index.ts
+++ b/src/rules/pressable-role-required/index.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '../../types';
 import { isPressable } from '../../helpers';
 
-const allowedRoles = ['button', 'link', 'imagebutton', 'radio'];
+const allowedRoles = ['button', 'link', 'imagebutton', 'radio', 'checkbox'];
 const allowedRolesMessage = allowedRoles.join(' or ');
 
 const rule: Rule = {
@@ -10,7 +10,7 @@ const rule: Rule = {
   assertion: (node) => allowedRoles.includes(node.props.accessibilityRole),
   help: {
     problem:
-      "This component is pressable but the user hasn't been informed that it behaves like a button/link/radio",
+      "This component is pressable but the user hasn't been informed that it behaves like a button/link/radio/checkbox",
     solution: `Set the 'accessibilityRole' prop to ${allowedRolesMessage}`,
     link: '',
   },


### PR DESCRIPTION
First of all, thank you for this package! Do you have any objections to allowing pressables to have a `checkbox` role? It seems to be a valid role for all currently supported versions of react-native (https://reactnative.dev/docs/accessibility#accessibilityrole).