### PR TITLE
chore: decrease Renovate concurrent PR limit

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,5 @@
 {
-  "extends": [
-    "config:base"
-  ],
+  "extends": ["config:base"],
   "labels": ["dependencies"],
-  "prConcurrentLimit": 10
+  "prConcurrentLimit": 4
 }


### PR DESCRIPTION
### Context

Right now, Renovate's concurrent PR limit is at 10, which fills up the repo's PR tab and frankly takes a lot of time to look over and maintain. 

### Objective

Lower Renovate's concurrent PR limit to 4, which will hopefully make maintaining the dependencies updated easier.