### PR TITLE
fix: add tab to list of allowed pressable roles

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -376,7 +376,7 @@ PODS:
     - React-perflogger (= 0.70.2)
   - RNCMaskedView (0.1.11):
     - React
-  - RNGestureHandler (2.7.0):
+  - RNGestureHandler (2.8.0):
     - React-Core
   - RNReanimated (2.10.0):
     - DoubleConversion
@@ -626,7 +626,7 @@ SPEC CHECKSUMS:
   React-runtimeexecutor: 80065f60af4f4b05603661070c8622bb3740bf16
   ReactCommon: 1209130f460e4aa9d255ddc75fa0a827ebf93dfb
   RNCMaskedView: 0e1bc4bfa8365eba5fbbb71e07fbdc0555249489
-  RNGestureHandler: 7673697e7c0e9391adefae4faa087442bc04af33
+  RNGestureHandler: 62232ba8f562f7dea5ba1b3383494eb5bf97a4d3
   RNReanimated: 60e291d42c77752a0f6d6f358387bdf225a87c6e
   RNScreens: f3230dd008a7d0ce5c0a8bc78ff12cf2315bda24
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608

--- a/src/rules/pressable-role-required/index.test.tsx
+++ b/src/rules/pressable-role-required/index.test.tsx
@@ -20,7 +20,7 @@ it("throws if 'accessibilityRole' prop not defined", () => {
   expect(() => run(<Button />)).toThrowError(rule.help.problem);
 });
 
-it("throws if 'accessibilityRole' prop has a value other than 'button' or 'link' or 'imagebutton'", () => {
+it("throws if 'accessibilityRole' prop has a value other than 'button', 'link', 'imagebutton', 'radio', or 'tab'", () => {
   const Button = () => (
     <TouchableOpacity accessibilityRole={'text'}>
       <Image source={TestAssets.heart['32px']} />
@@ -63,6 +63,16 @@ it("doesn't throw if 'accessibilityRole' prop has the value 'imagebutton'", () =
 it("doesn't throw if 'accessibilityRole' prop has the value 'radio'", () => {
   const Button = () => (
     <TouchableOpacity accessibilityRole={'radio'}>
+      <Image source={TestAssets.heart['32px']} />
+    </TouchableOpacity>
+  );
+
+  expect(() => run(<Button />)).not.toThrowError(rule.help.problem);
+});
+
+it("doesn't throw if 'accessibilityRole' prop has the value 'tab'", () => {
+  const Button = () => (
+    <TouchableOpacity accessibilityRole={'tab'}>
       <Image source={TestAssets.heart['32px']} />
     </TouchableOpacity>
   );

--- a/src/rules/pressable-role-required/index.ts
+++ b/src/rules/pressable-role-required/index.ts
@@ -1,7 +1,7 @@
 import type { Rule } from '../../types';
 import { isPressable } from '../../helpers';
 
-const allowedRoles = ['button', 'link', 'imagebutton', 'radio'];
+const allowedRoles = ['button', 'link', 'imagebutton', 'radio', 'tab'];
 const allowedRolesMessage = allowedRoles.join(' or ');
 
 const rule: Rule = {


### PR DESCRIPTION
Resolving one bug outlined here: https://github.com/aryella-lacerda/react-native-accessibility-engine/issues/307

adding "tabs" to the list of allowed pressable roles.

The podfile updates came when I ran `yarn bootstrap`