### PR TITLE
ci: add inputs to release and prerelease workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+name: Build
+
 on:
   pull_request:
     branches: [main]
@@ -29,7 +31,6 @@ jobs:
 
       - name: Build app for release
         run: xcodebuild -workspace example/ios/AccessibilityEngineExample.xcworkspace -scheme AccessibilityEngineExample -configuration Release -sdk iphonesimulator -derivedDataPath example/ios/build
-
 
   android:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,3 +1,5 @@
+name: Code quality
+
 on:
   pull_request:
     branches: [main]

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,5 +1,17 @@
+name: Prerelease
+
 on:
   workflow_dispatch:
+    inputs:
+      version_bump_type:
+        description: 'Would you like to manually control the version bump?'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
   prerelease:
@@ -32,7 +44,7 @@ jobs:
         run: npm config set scripts-prepend-node-path auto
 
       - name: Generate version number, commit, tag, and GitHub release
-        run: yarn release --ci --preRelease=rc
+        run: yarn release ${{ inputs.version_bump_type }} --ci --preRelease=rc
 
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,17 @@
+name: Release
+
 on:
   workflow_dispatch:
+    inputs:
+      version_bump_type:
+        description: 'Would you like to manually control the version bump?'
+        required: false
+        default: ''
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
 
 jobs:
   release:
@@ -32,7 +44,7 @@ jobs:
         run: npm config set scripts-prepend-node-path auto
 
       - name: Generate version number, commit, tag, and GitHub release
-        run: yarn release --ci
+        run: yarn release ${{ inputs.version_bump_type }}  --ci
 
       - name: Publish to NPM
         uses: JS-DevTools/npm-publish@v1


### PR DESCRIPTION
Adds the ability to manually determine the next version number for the CI release/prerelease workflows. The workflow options include:

- major
- minor
- patch